### PR TITLE
Code coverage (local reports)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ environments/
 *.sol.js
 environments/
 .idea
+
+# testrpc
+scTopics
+
+# test coverage
+coverage/
+coverageEnv/
+coverage.json

--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@
 - extended with Power concept: [Acebusters Economy Paper](http://www.acebusters.com/files/The%20Acebusters%20Economy.pdf)
 - [javascript simulator](http://acebusters.com/economy.html)
 
-### run
+### run tests
 
 ```
 npm install
 testrpc
 truffle test
 ```
+
+### code coverage
+
+```
+npm run coverage
+```
+
+Executes instrumented tests on a separate testrpc. Coverage report is dumped to the terminal and into `coverage/index.html` (Istanbul HTML format)
 
 ## License
 Code released under the [MIT License](https://github.com/acebusters/safe-token-sale/blob/master/LICENSE).

--- a/package.json
+++ b/package.json
@@ -5,16 +5,20 @@
   "author": "Johann Barbie",
   "license": "MIT",
   "main": "truffle.js",
+  "scripts": {
+    "coverage": "./node_modules/.bin/solidity-coverage"
+  },
   "keywords": [
     "token",
     "ethereum"
   ],
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.23.0",
-    "babel-polyfill": "^6.23.0"
+    "solidity-coverage": "^0.2.1"
   },
   "dependencies": {
     "bignumber.js": "^4.0.1"

--- a/truffle.js
+++ b/truffle.js
@@ -7,6 +7,13 @@ module.exports = {
       host: "localhost",
       port: 8545,
       network_id: "*" // Match any network id
+    },
+    coverage: {
+      host: "localhost",
+      network_id: "*",
+      port: 8555,
+      gas: 0xfffffffffff,
+      gasPrice: 0x01
     }
   }
 };


### PR DESCRIPTION
Measure code coverage locally by running `npm run coverage`. Running testrpc is not required (it will spawn its own)