### PR TITLE
Use bundled truffle and testrpc to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 - extended with Power concept: [Acebusters Economy Paper](http://www.acebusters.com/files/The%20Acebusters%20Economy.pdf)
 - [javascript simulator](http://acebusters.com/economy.html)
 
-### run
+### installation
 
 ```
 npm install
-testrpc
-truffle test
+```
+
+### run tests
+
+```
+npm run tests
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -5,16 +5,21 @@
   "author": "Johann Barbie",
   "license": "MIT",
   "main": "truffle.js",
+  "scripts": {
+    "test": "scripts/test.sh"
+  },
   "keywords": [
     "token",
     "ethereum"
   ],
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.23.0",
-    "babel-polyfill": "^6.23.0"
+    "ethereumjs-testrpc": "^4.0.1",
+    "truffle": "^3.4.5"
   },
   "dependencies": {
     "bignumber.js": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.23.0",
     "ethereumjs-testrpc": "^4.0.1",
-    "truffle": "^3.4.5"
+    "truffle": "3.4.5"
   },
   "dependencies": {
     "bignumber.js": "^4.0.1"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Based on https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/scripts/test.sh
+
+# Executes cleanup function at script exit.
+trap cleanup EXIT
+
+cleanup() {
+  # Kill the testrpc instance that we started (if we started one and if it's still running).
+  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
+    kill -9 $testrpc_pid
+  fi
+}
+
+testrpc_running() {
+  nc -z localhost 8545
+}
+
+if testrpc_running; then
+  echo "Using existing testrpc instance"
+else
+  echo "Starting our own testrpc instance"
+  testrpc > /dev/null &
+  testrpc_pid=$!
+fi
+
+node_modules/.bin/truffle test "$@"


### PR DESCRIPTION
Now everything is in package.json with the proper versions. Just `npm install` and you are good to go.

Benefits:
- no need to install and run testrpc manually
- no need to install truffle. Prevents #4 if the latest truffle is already installed globally

Inspired by OpenZeppelin setup.