### PR TITLE
Setup Travis CI and Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+dist: trusty
+sudo: required
+group: beta
+language: node_js
+node_js:
+  - "6"
+cache:
+  yarn: true
+script:
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ node_js:
 cache:
   yarn: true
 script:
-  - yarn test
+  - yarn run coverage
+after_script:
+  - cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/acebusters/economy.svg?branch=master)](https://travis-ci.org/acebusters/economy)
+[![Coverage Status](https://coveralls.io/repos/github/acebusters/economy/badge.svg?branch=master)](https://coveralls.io/github/acebusters/economy?branch=master)
+
 ## Safe Token Sale
 
 - idea according to [Vlad Zamfir's Safe Token Sale](https://medium.com/@Vlad_Zamfir/a-safe-token-sale-mechanism-8d73c430ddd1).

--- a/package.json
+++ b/package.json
@@ -5,16 +5,20 @@
   "author": "Johann Barbie",
   "license": "MIT",
   "main": "truffle.js",
+  "scripts": {
+    "coveralls": "scripts/coveralls.sh"
+  },
   "keywords": [
     "token",
     "ethereum"
   ],
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.23.0",
-    "babel-polyfill": "^6.23.0"
+    "coveralls": "^2.13.1"
   },
   "dependencies": {
     "bignumber.js": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "author": "Johann Barbie",
   "license": "MIT",
   "main": "truffle.js",
-  "scripts": {
-    "coveralls": "scripts/coveralls.sh"
-  },
   "keywords": [
     "token",
     "ethereum"


### PR DESCRIPTION
This should be merged after #6 and #7

After the merge code coverage will be available online at https://coveralls.io/github/acebusters/economy

@johannbarbie I've requested authorization for Coveralls to access acebusters github. This is NOT necessary (economy is a public repo!), you can reject this request.