### PR TITLE
chore: speed up tests by avoid unchanged contracts recompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm install
 npm run tests
 ```
 
+To avoid recompiling contracts all the time, consider patching truffle with supplied patch:
+```
+patch node_modules/truffle/build/cli.bundled.js truffle-test-cache.patch
+```
+
 ### code coverage
 
 ```

--- a/truffle-test-cache.patch
+++ b/truffle-test-cache.patch
@@ -1,0 +1,6 @@
+206816c206816,206818
+<       temp.mkdir('test-', function(err, temporaryDirectory) {
+---
+>       var temporaryDirectory = path.join(temp.dir, 'compiled_test_contracts');
+> 
+>       mkdirp(temporaryDirectory, function(err) {


### PR DESCRIPTION
Monkey patch for now. Source: https://github.com/trufflesuite/truffle/issues/343
Patch with
```
patch node_modules/truffle/build/cli.bundled.js truffle-test-cache.patch
```

then run `npm test` as usual. It should recompile only changed contracts now.