### PR TITLE
include price in purchase and sell

### DIFF
--- a/contracts/controller/ControllerInterface.sol
+++ b/contracts/controller/ControllerInterface.sol
@@ -18,8 +18,8 @@ contract ControllerInterface {
   function floor() constant returns (uint256);
   function ceiling() constant returns (uint256);
   
-  function purchase(address _sender) public payable returns (uint256);
-  function sell(address _from, uint256 _amountBabz) public;
+  function purchase(address _sender, uint256 _price) public payable returns (uint256);
+  function sell(address _from, uint256 _price, uint256 _amountBabz) public;
 
   // Power functions
   function powerBalanceOf(address _owner) constant returns (uint256);

--- a/contracts/controller/MarketEnabled.sol
+++ b/contracts/controller/MarketEnabled.sol
@@ -52,9 +52,10 @@ contract MarketEnabled is NutzEnabled {
     salePrice = _newSalePrice;
   }
 
-  function purchase(address _sender) public onlyNutz payable whenNotPaused returns (uint256) {
+  function purchase(address _sender, uint256 _price) public onlyNutz payable whenNotPaused returns (uint256) {
     // disable purchases if purchasePrice set to 0
     require(purchasePrice > 0);
+    require(_price == purchasePrice);
 
     uint256 amountBabz = purchasePrice.mul(msg.value).div(1000000); // 1,000,000 WEI, used as price factor
     // avoid deposits that issue nothing
@@ -76,10 +77,11 @@ contract MarketEnabled is NutzEnabled {
     return amountBabz;
   }
 
-  function sell(address _from, uint256 _amountBabz) public onlyNutz whenNotPaused {
+  function sell(address _from, uint256 _price, uint256 _amountBabz) public onlyNutz whenNotPaused {
     uint256 effectiveFloor = floor();
     uint256 INFINITY = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     require(effectiveFloor != INFINITY);
+    require(_price == effectiveFloor);
 
     uint256 amountWei = _amountBabz.mul(1000000).div(effectiveFloor);  // 1,000,000 WEI, used as price factor
     // make sure power pool shrinks proportional to economy

--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -101,6 +101,7 @@ contract PowerEnabled is MarketEnabled {
     _setActiveSupply(activeSupply().sub(_amountBabz));
     _setBabzBalanceOf(_from, babzBalanceOf(_from).sub(_amountBabz));
     _setPowerPool(powerPool().add(_amountBabz));
+    Power(powerAddr).powerUp(_from, amountPow);
   }
 
 

--- a/contracts/satelites/Nutz.sol
+++ b/contracts/satelites/Nutz.sol
@@ -22,9 +22,6 @@ contract Nutz is Ownable, ERC20 {
   // 10^0 - Babz
   string public symbol = "NTZ";
   uint256 public decimals = 12;
-  address internal powerUpContant = 0x000000000000000000000000000000706f776572; // 0xPOW
-  address internal powerDownConst = 0x00000000000000000000000000000061626e747a; // 0xNTZ
-  address internal sellConstant =   0x0000000000000000000000000000006574686572; // 0xETH
 
   // returns balances of active holders
   function balanceOf(address _owner) constant returns (uint) {
@@ -70,7 +67,7 @@ contract Nutz is Ownable, ERC20 {
 
   function powerDown(address _holder, uint256 _amountBabz) onlyOwner {
     // NTZ transfered from power pool to user's balance
-    Transfer(powerDownConst, _holder, _amountBabz);
+    Transfer(0x0, _holder, _amountBabz);
   }
 
 
@@ -85,12 +82,9 @@ contract Nutz is Ownable, ERC20 {
   }
 
   function transfer(address _to, uint256 _amountBabz, bytes _data) public returns (bool) {
-    if (_to == sellConstant) {
-      ControllerInterface(owner).sell(msg.sender, _amountBabz);
-      Sell(msg.sender, _amountBabz);
-    } else if (_to == powerUpContant) {
+    if (_to == 0x0) {
+      // powerup
       ControllerInterface(owner).powerUp(msg.sender, msg.sender, _amountBabz);
-      Transfer(msg.sender, _to, _amountBabz);
     } else {
       ControllerInterface(owner).transfer(msg.sender, _to, _amountBabz, _data);
       Transfer(msg.sender, _to, _amountBabz);
@@ -108,12 +102,13 @@ contract Nutz is Ownable, ERC20 {
   }
 
   function transferFrom(address _from, address _to, uint256 _amountBabz, bytes _data) public returns (bool) {
-    if (_to == powerUpContant) {
+    if (_to == 0x0) {
+      // powerup
       ControllerInterface(owner).powerUp(msg.sender, _from, _amountBabz);
     } else {
       ControllerInterface(owner).transferFrom(msg.sender, _from, _to, _amountBabz, _data);
+      Transfer(_from, _to, _amountBabz);
     }
-    Transfer(_from, _to, _amountBabz);
     return true;
   }
 
@@ -122,21 +117,19 @@ contract Nutz is Ownable, ERC20 {
     return transferFrom(_from, _to, _amountBabz, empty);
   }
 
-  function purchase() public payable {
+  function purchase(uint256 _price) public payable {
     require(msg.value > 0);
-    uint256 amountBabz = ControllerInterface(owner).purchase.value(msg.value)(msg.sender);
+    uint256 amountBabz = ControllerInterface(owner).purchase.value(msg.value)(msg.sender, _price);
     Purchase(msg.sender, amountBabz);
   }
 
-  function sell(uint256 _amountBabz) public {
-    ControllerInterface(owner).sell(msg.sender, _amountBabz);
+  function sell(uint256 _price, uint256 _amountBabz) public {
+    ControllerInterface(owner).sell(msg.sender, _price, _amountBabz);
     Sell(msg.sender, _amountBabz);
   }
 
   function powerUp(uint256 _amountBabz) public {
     ControllerInterface(owner).powerUp(msg.sender, msg.sender, _amountBabz);
-    // NTZ transfered from user's balance to power pool
-    Transfer(msg.sender, powerUpContant, _amountBabz);
   }
 
 }

--- a/contracts/satelites/Power.sol
+++ b/contracts/satelites/Power.sol
@@ -48,7 +48,7 @@ contract Power is Ownable, ERC20Basic {
     // make Power not transferable
     require(_to == 0x0);
     ControllerInterface(owner).createDownRequest(msg.sender, _amountPower);
-    Transfer(msg.sender, owner, _amountPower);
+    Transfer(msg.sender, 0x0, _amountPower);
     return true;
   }
 

--- a/contracts/satelites/Power.sol
+++ b/contracts/satelites/Power.sol
@@ -11,7 +11,6 @@ contract Power is Ownable, ERC20Basic {
   string public name = "Acebusters Power";
   string public symbol = "ABP";
   uint256 public decimals = 12;
-  address internal powerDownConst = 0x00000000000000000000000000000061626e747a; // 0xNTZ
                                     
 
   function balanceOf(address _holder) constant returns (uint256 balance) {
@@ -31,10 +30,14 @@ contract Power is Ownable, ERC20Basic {
   // ########### ADMIN FUNCTIONS ################
   // ############################################
 
-  function slashPower(address _holder, uint256 _value, bytes32 _data) onlyOwner {
+  function slashPower(address _holder, uint256 _value, bytes32 _data) public onlyOwner {
     Slashing(_holder, _value, _data);
   }
 
+  function powerUp(address _holder, uint256 _value) public onlyOwner {
+    // NTZ transfered from user's balance to power pool
+    Transfer(0x0, _holder, _value);
+  }
 
   // ############################################
   // ########### PUBLIC FUNCTIONS ###############
@@ -43,7 +46,7 @@ contract Power is Ownable, ERC20Basic {
   // registers a powerdown request
   function transfer(address _to, uint256 _amountPower) public returns (bool success) {
     // make Power not transferable
-    require(_to == powerDownConst);
+    require(_to == 0x0);
     ControllerInterface(owner).createDownRequest(msg.sender, _amountPower);
     Transfer(msg.sender, owner, _amountPower);
     return true;

--- a/contracts/satelites/PullPayment.sol
+++ b/contracts/satelites/PullPayment.sol
@@ -17,7 +17,7 @@ contract PullPayment is Ownable {
     uint256 date;   // 
   }
 
-  uint public dailyLimit = 1000000000000000000001;  // 1 ETH
+  uint public dailyLimit = 1000000000000000000000;  // 1 ETH
   uint public lastDay;
   uint public spentToday;
 
@@ -83,7 +83,8 @@ contract PullPayment is Ownable {
       lastDay = now;
       spentToday = 0;
     }
-    if (spentToday.add(amount) > dailyLimit || spentToday.add(amount) < spentToday) {
+    // not using safe math because we don't want to throw;
+    if (spentToday + amount > dailyLimit || spentToday + amount < spentToday) {
       return false;
     }
     return true;

--- a/test/event.js
+++ b/test/event.js
@@ -45,7 +45,7 @@ contract('PowerEvent', (accounts) => {
     await controller.addAdmin(event1.address);
     await event1.startCollection();
     // event #1 - buyin
-    await nutz.purchase({from: FOUNDERS, value: WEI_AMOUNT });
+    await nutz.purchase(1200000000, {from: FOUNDERS, value: WEI_AMOUNT });
     // event #1 - burn
     await event1.stopCollection();
     await event1.completeClosed();
@@ -69,7 +69,7 @@ contract('PowerEvent', (accounts) => {
     // event #2 - buy in
     await controller.addAdmin(event2.address);
     await event2.startCollection();
-    await nutz.purchase({from: INVESTORS, value: hardCap2 });
+    await nutz.purchase(30000, {from: INVESTORS, value: hardCap2 });
     // event #2 - burn
     await event2.stopCollection();
     await event2.completeClosed();

--- a/test/power.js
+++ b/test/power.js
@@ -46,7 +46,7 @@ contract('Power', (accounts) => {
     await controller.moveCeiling(CEILING_PRICE);
     await controller.setDowntime(DOWNTIME);
     // get some NTZ for 1 ETH
-    await nutz.purchase({from: ALICE, value: WEI_AMOUNT });
+    await nutz.purchase(CEILING_PRICE, {from: ALICE, value: WEI_AMOUNT });
     await controller.dilutePower(0);
     const authorizedPower = await power.totalSupply.call();
     await controller.setMaxPower(authorizedPower);
@@ -65,7 +65,7 @@ contract('Power', (accounts) => {
     assert.equal(powBalAlice.toNumber(), powTotal.div(2.5).toNumber(), 'first power up failed');
 
     // get some NTZ for 1 ETH with other account
-    await nutz.purchase({from: BOB, value: WEI_AMOUNT });
+    await nutz.purchase(CEILING_PRICE, {from: BOB, value: WEI_AMOUNT });
     const babzTotal2 = await nutz.totalSupply.call();
     
     // ntz13k is 1/5 of total Nutz supply
@@ -73,7 +73,7 @@ contract('Power', (accounts) => {
     assert.equal(ntz13k.toNumber(), babzTotal2.div(5).toNumber());
     // powerup these tokens and check shares
     await nutz.approve(accounts[2], ntz13k, {from: BOB});
-    await nutz.transferFrom(BOB, '0x000000000000000000000000000000706f776572', ntz13k, '0x00', {from: accounts[2]});
+    await nutz.transferFrom(BOB, 0, ntz13k, '0x00', {from: accounts[2]});
     const powBalBob = await power.balanceOf.call(BOB);
     assert.equal(powBalBob.toNumber(), powTotal.div(2.5).toNumber(), 'second power up failed');
     
@@ -84,7 +84,7 @@ contract('Power', (accounts) => {
     // power down and check
     const babzBalAliceBefore = await nutz.balanceOf.call(ALICE);
     const babzActiveBefore = await nutz.activeSupply.call();
-    await power.transfer('0x00000000000000000000000000000061626e747a', pow20pc, "0x00");
+    await power.transfer(0, pow20pc, "0x00");
     await power.downTickTest(0, (Date.now() / 1000 | 0) + DOWNTIME);
     const powBalAliceAfter = await power.balanceOf.call(ALICE);
     assert.equal(powBalAliceAfter.toNumber(), pow20pc.toNumber(), 'power down failed in Power contract');
@@ -107,7 +107,7 @@ contract('Power', (accounts) => {
     const FOUNDERS = accounts[1];
     const INVESTORS = accounts[2];
     
-    await nutz.purchase({from: FOUNDERS, value: WEI_AMOUNT });
+    await nutz.purchase(CEILING_PRICE * 20, {from: FOUNDERS, value: WEI_AMOUNT });
     const expectedBal = (WEI_AMOUNT * CEILING_PRICE * 20) / PRICE_FACTOR.toNumber();
     assert.equal(await nutz.balanceOf.call(FOUNDERS), expectedBal);
     // Founder Burn
@@ -123,7 +123,7 @@ contract('Power', (accounts) => {
     // increase token price for investors
     await controller.moveCeiling(CEILING_PRICE);
     await controller.moveFloor(CEILING_PRICE * 2);
-    await nutz.purchase({from: INVESTORS, value: WEI_AMOUNT * 7 });
+    await nutz.purchase(CEILING_PRICE, {from: INVESTORS, value: WEI_AMOUNT * 7 });
     // Invetors Burn
     const totalBabz2 = await nutz.totalSupply.call();
     const investorsBal = await nutz.balanceOf.call(INVESTORS);
@@ -164,7 +164,7 @@ contract('Power', (accounts) => {
     const power = Power.at(await controller.powerAddr.call());
     
     // get some NTZ for 1 ETH
-    await nutz.purchase({from: accounts[0], value: WEI_AMOUNT });
+    await nutz.purchase(CEILING_PRICE, {from: accounts[0], value: WEI_AMOUNT });
     await controller.dilutePower(0);
     const authorizedPower = await power.totalSupply.call();
     await controller.setMaxPower(authorizedPower);


### PR DESCRIPTION
@troggy pointed out, that we should include assumed price in purchase and sell to avoid situation where a price changes while user sends his transaction, and the trade is executed at undesirable conditions.