### PR TITLE
Fix: Use transfer instead of send

### DIFF
--- a/contracts/satelites/PullPayment.sol
+++ b/contracts/satelites/PullPayment.sol
@@ -73,7 +73,7 @@ contract PullPayment is Ownable {
 
     payments[untrustedRecipient].value = 0;
 
-    assert(untrustedRecipient.send(amountWei));
+    untrustedRecipient.transfer(amountWei);
   }
 
   /*


### PR DESCRIPTION
"Prefer newer Solidity constructs":
https://github.com/acebusters/economy/blob/master/contracts/Nutz.sol#L166
.transfer() can be used instead
