### PR TITLE
move erc23 check to satellite

### DIFF
--- a/contracts/controller/ControllerInterface.sol
+++ b/contracts/controller/ControllerInterface.sol
@@ -15,14 +15,14 @@ contract ControllerInterface {
   function allowance(address _owner, address _spender) constant returns (uint256);
 
   function approve(address _owner, address _spender, uint256 _amountBabz) public;
-  function transfer(address _from, address _to, uint256 _amountBabz, bytes _data) public;
+  function transfer(address _from, address _to, uint256 _amountBabz, bytes _data) public returns (bool);
   function transferFrom(address _sender, address _from, address _to, uint256 _amountBabz, bytes _data) public returns (bool);
 
   // Market functions
   function floor() constant returns (uint256);
   function ceiling() constant returns (uint256);
 
-  function purchase(address _sender, uint256 _price) public payable returns (uint256);
+  function purchase(address _sender, uint256 _price) public payable returns (uint256, bool);
   function sell(address _from, uint256 _price, uint256 _amountBabz) public;
 
   // Power functions

--- a/contracts/controller/MarketEnabled.sol
+++ b/contracts/controller/MarketEnabled.sol
@@ -54,7 +54,7 @@ contract MarketEnabled is NutzEnabled {
     salePrice = _newSalePrice;
   }
 
-  function purchase(address _sender, uint256 _price) public onlyNutz payable whenNotPaused returns (uint256) {
+  function purchase(address _sender, uint256 _price) public onlyNutz payable whenNotPaused returns (uint256, bool) {
     // disable purchases if purchasePrice set to 0
     require(purchasePrice > 0);
     require(_price == purchasePrice);
@@ -73,10 +73,7 @@ contract MarketEnabled is NutzEnabled {
     }
     _setActiveSupply(activeSup.add(amountBabz));
     _setBabzBalanceOf(_sender, babzBalanceOf(_sender).add(amountBabz));
-
-    bytes memory empty;
-    _checkDestination(address(this), _sender, amountBabz, empty);
-    return amountBabz;
+    return (amountBabz, onlyContractHolders);
   }
 
   function sell(address _from, uint256 _price, uint256 _amountBabz) public onlyNutz whenNotPaused {

--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -169,9 +169,7 @@ contract PowerEnabled is MarketEnabled {
     _setPowerPool(powerPool().sub(amountBabz));
     _setActiveSupply(activeSupply().add(amountBabz));
     _setBabzBalanceOf(req.owner, babzBalanceOf(req.owner).add(amountBabz));
-    Nutz(nutzAddr).powerDown(req.owner, amountBabz);
-    bytes memory empty;
-    _checkDestination(powerAddr, req.owner, amountBabz, empty);
+    Nutz(nutzAddr).powerDown(powerAddr, req.owner, amountBabz, onlyContractHolders);
 
     // down request completed
     if (req.left == 0) {


### PR DESCRIPTION
otherwise tables get confused, because `tokenFallback()` is not called with nutz contract as `msg.sender`

check here: 
https://github.com/acebusters/contracts/blob/master/contracts/Table.sol#L115

and here:
https://github.com/acebusters/contracts/blob/master/contracts/Table.sol#L312