### PR TITLE
moved reserve to Nutz satellite

### DIFF
--- a/contracts/PullPayInterface.sol
+++ b/contracts/PullPayInterface.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.11;
+
+contract PullPayInterface {
+  function asyncSend(address _dest) public payable;
+}

--- a/contracts/controller/ControllerInterface.sol
+++ b/contracts/controller/ControllerInterface.sol
@@ -5,6 +5,7 @@ contract ControllerInterface {
 
   // State Variables
   bool public paused;
+  address public nutzAddr;
 
   // Nutz functions
   function babzBalanceOf(address _owner) constant returns (uint256);
@@ -22,8 +23,8 @@ contract ControllerInterface {
   function floor() constant returns (uint256);
   function ceiling() constant returns (uint256);
 
-  function purchase(address _sender, uint256 _price) public payable returns (uint256);
-  function sell(address _from, uint256 _price, uint256 _amountBabz) public;
+  function purchase(address _sender, uint256 _value, uint256 _price) public returns (uint256);
+  function sell(address _from, uint256 _price, uint256 _amountBabz);
 
   // Power functions
   function powerBalanceOf(address _owner) constant returns (uint256);

--- a/contracts/controller/MarketEnabled.sol
+++ b/contracts/controller/MarketEnabled.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.11;
 
 import "../satelites/PullPayment.sol";
 import "./NutzEnabled.sol";
+import "../satelites/Nutz.sol";
 
 contract MarketEnabled is NutzEnabled {
 
@@ -30,10 +31,10 @@ contract MarketEnabled is NutzEnabled {
   // returns either the salePrice, or if reserve does not suffice
   // for active supply, returns maxFloor
   function floor() constant returns (uint256) {
-    if (this.balance == 0) {
+    if (nutzAddr.balance == 0) {
       return INFINITY;
     }
-    uint256 maxFloor = activeSupply().mul(1000000).div(this.balance); // 1,000,000 WEI, used as price factor
+    uint256 maxFloor = activeSupply().mul(1000000).div(nutzAddr.balance); // 1,000,000 WEI, used as price factor
     // return max of maxFloor or salePrice
     return maxFloor >= salePrice ? maxFloor : salePrice;
   }
@@ -49,17 +50,17 @@ contract MarketEnabled is NutzEnabled {
     // that the sale mechanism is no longer able to buy back all tokens at
     // the floor price if those funds were to be withdrawn.
     if (_newSalePrice < INFINITY) {
-      require(this.balance >= activeSupply().mul(1000000).div(_newSalePrice)); // 1,000,000 WEI, used as price factor
+      require(nutzAddr.balance >= activeSupply().mul(1000000).div(_newSalePrice)); // 1,000,000 WEI, used as price factor
     }
     salePrice = _newSalePrice;
   }
 
-  function purchase(address _sender, uint256 _price) public onlyNutz payable whenNotPaused returns (uint256) {
+  function purchase(address _sender, uint256 _value, uint256 _price) public onlyNutz whenNotPaused returns (uint256) {
     // disable purchases if purchasePrice set to 0
     require(purchasePrice > 0);
     require(_price == purchasePrice);
 
-    uint256 amountBabz = purchasePrice.mul(msg.value).div(1000000); // 1,000,000 WEI, used as price factor
+    uint256 amountBabz = purchasePrice.mul(_value).div(1000000); // 1,000,000 WEI, used as price factor
     // avoid deposits that issue nothing
     // might happen with very high purchase price
     require(amountBabz > 0);
@@ -93,8 +94,7 @@ contract MarketEnabled is NutzEnabled {
     }
     _setActiveSupply(activeSup.sub(_amountBabz));
     _setBabzBalanceOf(_from, babzBalanceOf(_from).sub(_amountBabz));
-    assert(amountWei <= this.balance);
-    PullPayment(pullAddr).asyncSend.value(amountWei)(_from);
+    Nutz(nutzAddr).asyncSend(pullAddr, _from, amountWei);
   }
 
 
@@ -104,8 +104,8 @@ contract MarketEnabled is NutzEnabled {
     // allocateEther fails if allocating those funds would mean that the
     // sale mechanism is no longer able to buy back all tokens at the floor
     // price if those funds were to be withdrawn.
-    require(this.balance.sub(_amountWei) >= activeSupply().mul(1000000).div(salePrice)); // 1,000,000 WEI, used as price factor
-    PullPayment(pullAddr).asyncSend.value(_amountWei)(_beneficiary);
+    require(nutzAddr.balance.sub(_amountWei) >= activeSupply().mul(1000000).div(salePrice)); // 1,000,000 WEI, used as price factor
+    Nutz(nutzAddr).asyncSend(pullAddr, _beneficiary, _amountWei);
   }
 
 }

--- a/contracts/controller/PowerEnabled.sol
+++ b/contracts/controller/PowerEnabled.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.11;
 
 import "../satelites/Power.sol";
-import "../satelites/Nutz.sol";
 import "./MarketEnabled.sol";
 import "./WithPowerDownRequests.sol";
 

--- a/contracts/policies/PowerEvent.sol
+++ b/contracts/policies/PowerEvent.sol
@@ -31,6 +31,7 @@ contract PowerEvent {
   // Params
   address public controllerAddr;
   address public powerAddr;
+  address public nutzAddr;
   uint256 public initialReserve;
   uint256 public initialSupply;
 
@@ -93,8 +94,9 @@ contract PowerEvent {
     // read initial values
     var contr = Controller(controllerAddr);
     powerAddr = contr.powerAddr();
+    nutzAddr = contr.nutzAddr();
     initialSupply = contr.activeSupply().add(contr.powerPool()).add(contr.burnPool());
-    initialReserve = controllerAddr.balance;
+    initialReserve = nutzAddr.balance;
     uint256 ceiling = contr.ceiling();
     // move ceiling
     uint256 newCeiling = ceiling.mul(discountRate).div(RATE_FACTOR);
@@ -104,7 +106,7 @@ contract PowerEvent {
   }
 
   function stopCollection() isState(EventState.Collecting) {
-    uint256 collected = controllerAddr.balance.sub(initialReserve);
+    uint256 collected = nutzAddr.balance.sub(initialReserve);
     if (now > startTime.add(maxDuration)) {
       if (collected >= softCap) {
         // softCap reached, close
@@ -155,7 +157,7 @@ contract PowerEvent {
     uint256 authorizedPower = PowerContract.totalSupply();
     contr.setMaxPower(authorizedPower);
     // pay out milestone
-    uint256 collected = controllerAddr.balance.sub(initialReserve);
+    uint256 collected = nutzAddr.balance.sub(initialReserve);
     for (uint256 i = 0; i < milestoneRecipients.length; i++) {
       uint256 payoutAmount = collected.mul(milestoneShares[i]).div(RATE_FACTOR);
       contr.allocateEther(payoutAmount, milestoneRecipients[i]);

--- a/contracts/satelites/PullPayment.sol
+++ b/contracts/satelites/PullPayment.sol
@@ -49,7 +49,7 @@ contract PullPayment is Ownable {
     payments[_owner].date = _newDate;
   }
 
-  function asyncSend(address _dest) public payable onlyOwner {
+  function asyncSend(address _dest) public payable {
     require(msg.value > 0);
     uint256 newValue = payments[_dest].value.add(msg.value);
     uint256 newDate;

--- a/contracts/satelites/PullPayment.sol
+++ b/contracts/satelites/PullPayment.sol
@@ -23,10 +23,16 @@ contract PullPayment is Ownable {
 
   mapping(address => Payment) internal payments;
 
+  modifier onlyNutz() {
+    require(msg.sender == ControllerInterface(owner).nutzAddr());
+    _;
+  }
+
   modifier whenNotPaused () {
     require(!ControllerInterface(owner).paused());
      _;
   }
+
   function balanceOf(address _owner) constant returns (uint256 value) {
     return payments[_owner].value;
   }
@@ -49,7 +55,7 @@ contract PullPayment is Ownable {
     payments[_owner].date = _newDate;
   }
 
-  function asyncSend(address _dest) public payable {
+  function asyncSend(address _dest) public payable onlyNutz {
     require(msg.value > 0);
     uint256 newValue = payments[_dest].value.add(msg.value);
     uint256 newDate;

--- a/test/controller.js
+++ b/test/controller.js
@@ -47,7 +47,7 @@ contract('Controller', (accounts) => {
     const babzBalAfter = await nutz.balanceOf.call(accounts[0]);
     assert.equal(babzBalAfter.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
     // check eth migrated
-    const reserveWei = web3.eth.getBalance(newController.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'ether wasn\'t sent to contract');
     // check transfers with new controller
     await nutz.transfer(accounts[1], babzBalAfter);

--- a/test/market.js
+++ b/test/market.js
@@ -89,7 +89,7 @@ contract('MarketEnabled', (accounts) => {
         // purchase some tokens with 1 ether
         await nutz.purchase(sellPrice, { from: accounts[0], value: ONE_ETH });
 
-        const reserveWei = web3.eth.getBalance(market.address);
+        const reserveWei = web3.eth.getBalance(nutz.address);
         assert.equal(reserveWei.toNumber(), ONE_ETH, '1 ETH should be sent to contract');
       });
 

--- a/test/nutz.js
+++ b/test/nutz.js
@@ -58,7 +58,7 @@ contract('Nutz', (accounts) => {
     assert.equal(babzBalance.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
     const supplyBabz = await nutz.activeSupply.call();
     assert.equal(supplyBabz.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued');
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'ether wasn\'t sent to contract');
   });
 
@@ -79,7 +79,7 @@ contract('Nutz', (accounts) => {
     assert.equal(babzBalance.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
     const supplyBabz = await nutz.activeSupply.call();
     assert.equal(supplyBabz.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued');
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'ether wasn\'t sent to contract');
   });
 
@@ -116,7 +116,7 @@ contract('Nutz', (accounts) => {
     let allocationWei = await pull.balanceOf.call(accounts[0]);
     const HALF_ETH = web3.toWei(0.5, 'ether');
     assert.equal(allocationWei.toString(), HALF_ETH, 'ether wasn\'t allocated for withdrawal');
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toString(), HALF_ETH, 'ether allocation wasn\'t deducted from reserve');
     // pull the ether from the account
     const before = web3.eth.getBalance(accounts[0]);
@@ -144,7 +144,7 @@ contract('Nutz', (accounts) => {
     let allocationWeiBefore = await pull.balanceOf.call(accounts[0]);
     const HALF_ETH = web3.toWei(0.5, 'ether');
     assert.equal(allocationWeiBefore.toString(), HALF_ETH, 'ether wasn\'t allocated for withdrawal');
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toString(), HALF_ETH, 'ether allocation wasn\'t deducted from reserve');
     // pull the ether from the account
     const before = web3.eth.getBalance(accounts[0]);
@@ -291,7 +291,7 @@ contract('Nutz', (accounts) => {
     // purchase NTZ for 1 ETH
     await nutz.purchase(ceiling, {from: accounts[0], value: ONE_ETH });
     const floor = await controller.floor.call();
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'reserve incorrect');
     const babzBalance = await nutz.balanceOf.call(accounts[0]);
     assert.equal(babzBalance.toNumber(), ceiling.mul(ONE_ETH).div(PRICE_FACTOR).toNumber(), 'token wasn\'t issued to account');
@@ -332,7 +332,7 @@ contract('Nutz', (accounts) => {
       assert.equal(babzBalanceAfter.toNumber(), babzBalanceBefore, 'balance should stay same after failed purchase');
       const supplyBabz = await nutz.activeSupply.call();
       assert.equal(supplyBabz.toNumber(), babzBalanceBefore, 'activeSupply should stay same after failed purchase');
-      const reserveWei = web3.eth.getBalance(controller.address);
+      const reserveWei = web3.eth.getBalance(nutz.address);
       assert.equal(reserveWei.toNumber(), ONE_ETH, 'ether should not have been deposited');
     }
   });
@@ -344,7 +344,7 @@ contract('Nutz', (accounts) => {
     await controller.moveCeiling(ceiling);
     await nutz.purchase(ceiling, {from: accounts[0], value: ONE_ETH });
     let supplyBabz = await nutz.activeSupply.call(accounts[0]);
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(supplyBabz.toNumber(), ceiling.mul(ONE_ETH).div(PRICE_FACTOR).toNumber(), 'amount wasn\'t issued to account');
     // move ceiling so we can move floor
     await controller.moveCeiling(2000);
@@ -369,7 +369,7 @@ contract('Nutz', (accounts) => {
 
     await nutz.purchase(ceiling, {from: accounts[0], value: ONE_ETH });
     const floor = await controller.floor.call();
-    const reserveWei = web3.eth.getBalance(controller.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'reserve incorrect');
     const babzBalance = await nutz.balanceOf.call(accounts[0]);
     assert.equal(babzBalance.toNumber(), ceiling.mul(ONE_ETH).div(PRICE_FACTOR).toNumber(), 'token wasn\'t issued to account');

--- a/test/power.js
+++ b/test/power.js
@@ -141,7 +141,7 @@ contract('Power', (accounts) => {
     const floor = await controller.floor.call();
     const ceiling = await controller.ceiling.call();
     const totalReserve = web3.toWei(8, 'ether');
-    const weiReserve = web3.eth.getBalance(controller.address);
+    const weiReserve = web3.eth.getBalance(nutz.address);
     assert.equal(weiReserve.toNumber(), totalReserve, 'reserve incorrect');
     // payout 10 percent
     const payoutAmount = totalReserve/2;

--- a/test/upgradeEvent.js
+++ b/test/upgradeEvent.js
@@ -53,7 +53,7 @@ contract('UpgradeEvent', (accounts) => {
     const babzBalAfter = await nutz.balanceOf.call(accounts[0]);
     assert.equal(babzBalAfter.toNumber(), ceiling.mul(NTZ_DECIMALS).toNumber(), 'token wasn\'t issued to account');
     // check eth migrated
-    const reserveWei = web3.eth.getBalance(nextController.address);
+    const reserveWei = web3.eth.getBalance(nutz.address);
     assert.equal(reserveWei.toNumber(), ONE_ETH, 'ether wasn\'t sent to contract');
     // check transfers with next controller
     await nutz.transfer(accounts[1], babzBalAfter);


### PR DESCRIPTION
following reasons:
- some ico websites want to know the address of the contract (used as destination for investment, and to read out the amount raised)
- when sending ETH to Nutz contract, ETH is forwarded to Contoroller, looks strange in etherscan
- forwarding eth between contracts costs more gas

=> we keep all ETH in NTZ satellite, instead of controller.